### PR TITLE
Set to 0 the margin and the padding on body to avoid appear the scroll bar

### DIFF
--- a/style.css
+++ b/style.css
@@ -11,6 +11,8 @@ canvas
 body
 {
 	background-color: #000000;
+  padding: 0;
+  margin: 0;
 }
 
 @font-face {


### PR DESCRIPTION
The default's margin and padding of the body makes the content to be scrollable. This change fixes it